### PR TITLE
Made idempotent, fixed path bugs and added optional OpenJDK 8 backport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ Java Playbook for Ansible
 
 This playbook will install Java OpenJDK.
 
+It uses the [ppa:openjdk-r/ppa](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa) repository for Ubuntu, to add backports of Java OpenJDK 8.
 
 Support open source!

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Java Playbook for Ansible
 
 This playbook will install Java OpenJDK.
 
-It uses the [ppa:openjdk-r/ppa](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa) repository for Ubuntu, to add backports of Java OpenJDK 8.
+It optionally uses the [ppa:openjdk-r/ppa](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa) repository for Ubuntu, to add backports of Java, for example OpenJDK 8 on Ubuntu 14.04. Set `use_openjdk_ppa: true` to use the repo.
 
 Support open source!

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 java_version: "7"
 java_register_alternative: false
 java_register_env: false
+use_openjdk_ppa: false

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,6 @@
 - name: Add Ubuntu OpenJDK repo (for additional Java versions)
   apt_repository: repo='ppa:openjdk-r/ppa' state=present
-  when: ansible_lsb.id == 'Ubuntu'
+  when: ansible_lsb.id == 'Ubuntu' and use_openjdk_ppa
 
 - name: Install os packages
   apt: 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,13 +11,13 @@
     - openjdk-{{java_version}}-jre-headless
     - openjdk-{{java_version}}-jdk
 
-- name: Resolve {{java_libjvm_path}}
-  shell: find {{java_libjvm_path}}
+- name: Find path for new libjvm.so
+  shell: '{ find -L {{java_base_path}} -type f -path "{{java_base_path}}/java-1.{{java_version}}*openjdk*/libjvm.so"; find -L {{java_base_path}} -type f -path "{{java_base_path}}/java-{{java_version}}*openjdk*/libjvm.so"; } | head -n 1'
   register: libjvm_path_resolved
   changed_when: false
 
 # Here we get back to ansible land...
-- name: Check for {{libjvm_path_resolved}}
+- name: Check for libjvm_path_resolved
   stat: 
     path: "{{libjvm_path_resolved.stdout}}"
   register: libjvm

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,3 +1,7 @@
+- name: Add Ubuntu OpenJDK repo (for additional Java versions)
+  apt_repository: repo='ppa:openjdk-r/ppa' state=present
+  when: ansible_lsb.id == 'Ubuntu'
+
 - name: Install os packages
   apt: 
     pkg: "{{item}}"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,6 +10,7 @@
 - name: Resolve {{java_libjvm_path}}
   shell: find {{java_libjvm_path}}
   register: libjvm_path_resolved
+  changed_when: false
 
 # Here we get back to ansible land...
 - name: Check for {{libjvm_path_resolved}}
@@ -18,7 +19,7 @@
   register: libjvm
 
 - name: Link libjvm
-  shell: ln -nsf {{libjvm_path_resolved.stdout}} {{java_libjvm_symlink_path}}
+  file: src={{libjvm_path_resolved.stdout}} dest={{java_libjvm_symlink_path}} state=link force=yes
   when: libjvm.stat.exists == true
 
 - name: Check if symlink created

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,14 +6,21 @@
   when: ansible_os_family == "RedHat"
 
 - name: Find path for new JAVA binary
-  shell: update-alternatives --query java | grep Alternative | grep openjdk | grep -m 1 -e 'java-\(1.\)\{0,1\}{{java_version}}' | cut -f 2 -d " " 
+  shell: update-alternatives --query java | grep Alternative | grep openjdk | grep -m 1 -e 'java-\(1\.\)\{0,1\}{{java_version}}' | cut -f 2 -d " " 
   register: java_bin_path
   changed_when: false
+  when: java_register_alternative
 
 - name: Update alternatives to point to new JAVA installation
   alternatives: name=java path="{{java_bin_path.stdout}}"
   when: java_register_alternative
 
+- name: Find path for new JAVA home
+  shell: '{ find -L {{java_base_path}} -type f -path "{{java_base_path}}/java-1.{{java_version}}*openjdk*/jre/bin/java"; find -L {{java_base_path}} -type f -path "{{java_base_path}}/java-{{java_version}}*openjdk*/jre/bin/java"; } | head -n 1'
+  register: java_home_path
+  changed_when: false
+  when: java_register_env
+
 - name: Register JAVA_HOME env variable
-  lineinfile: dest=/etc/profile regexp="^(export JAVA_HOME=)" state=present line="export JAVA_HOME={{java_bin_path.stdout | replace('/jre/bin/java','')}}"
+  lineinfile: dest=/etc/profile regexp="^(export JAVA_HOME=)" state=present line="export JAVA_HOME={{java_home_path.stdout | replace('/jre/bin/java','')}}"
   when: java_register_env

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,15 @@
 - include: RedHat.yml
   when: ansible_os_family == "RedHat"
 
-- name: update alternatives to point to new JAVA installed
-  alternatives: name=java path=/usr/lib/jvm/java-1.{{java_version}}.0-openjdk/jre/bin/java
+- name: Find path for new JAVA binary
+  shell: update-alternatives --query java | grep Alternative | grep openjdk | grep -m 1 -e 'java-\(1.\)\{0,1\}{{java_version}}' | cut -f 2 -d " " 
+  register: java_bin_path
+  changed_when: false
+
+- name: Update alternatives to point to new JAVA installation
+  alternatives: name=java path="{{java_bin_path.stdout}}"
   when: java_register_alternative
 
 - name: Register JAVA_HOME env variable
-  lineinfile: dest=/etc/profile state=present line="export JAVA_HOME=/usr/lib/jvm/java-1.{{java_version}}.0-openjdk"
+  lineinfile: dest=/etc/profile regexp="^(export JAVA_HOME=)" state=present line="export JAVA_HOME={{java_bin_path.stdout | replace('/jre/bin/java','')}}"
   when: java_register_env

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 java_playbook_version: "0.1.4" # playbook version
-java_libjvm_path: "/usr/lib/jvm/java-{{java_version}}-*/jre/lib/*/server/libjvm.so"
+java_base_path: "/usr/lib/jvm"
 java_libjvm_symlink_path: "/usr/lib/libjvm.so"


### PR DESCRIPTION
My goal was to deploy OpenJDK 7 or 8 on Ubuntu 14.04, so my following tweaks are to that end. I haven't tested on any other OS.

Changes:
1. Added an optional PPA with OpenJDK backports for Ubuntu
2. When `java_register_alternative: true`: Fixed incorrect path for update-alternatives.  I now query the update-alternatives tool and select a valid alternative.
3. When `java_register_env: true`: Fixed incorrect path for setting JAVA_HOME, since my path has -amd64 for example. I've used a more generic search pattern.
4. Switched to using Ansible modules, instead of shell where possible.
5. Made sure all steps are idempotent, so there are now no changed states when re-running the role.